### PR TITLE
Fixed package to allow clients to use require('bower-license')

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.2.1",
   "description": "Generates a list of bower dependencies for a project",
   "preferGlobal": "true",
+  "main": "./lib/index",
   "bin": {
     "bower-license": "./bin/bower-license"
   },


### PR DESCRIPTION
I need to use bower-license programmatically from a grunt file. `require('bower-license')` currently throws an error. Adding a `main` property to the package.json file fixes this.
