### PR TITLE
if licenses array only contains one license remove the array

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,7 @@ exports.init = function(options, callback){
     }
     // check each bower package recursively
     if (!fs.existsSync(options.directory)){
-        throw 'Run bower install first';        
+        throw 'Run bower install first';
     }
     var packages = fs.readdirSync(options.directory);
     packages.forEach(function(package){
@@ -40,7 +40,6 @@ exports.init = function(options, callback){
                             moduleInfo.licenses = moduleInfo.licenses.concat(npmData[packageName].licenses)
                         if (npmData[packageName].repository)
                             moduleInfo.repository = npmData[packageName].repository;
-
                     }
 
                     // enhance with package-license

--- a/lib/index.js
+++ b/lib/index.js
@@ -44,7 +44,7 @@ exports.init = function(options, callback){
 
                     // enhance with package-license
                     var licenseFromFS = packageLicense(path.resolve(options.directory, package));
-                    if (licenseFromFS) moduleInfo.licenses = licenseFromFS;
+                    if (licenseFromFS) moduleInfo.licenses = moduleInfo.licenses.concat(licenseFromFS);
 
                     if (moduleInfo.licenses.length === 0) moduleInfo.licenses = 'UNKNOWN';
                     

--- a/lib/index.js
+++ b/lib/index.js
@@ -47,6 +47,10 @@ exports.init = function(options, callback){
                     if (licenseFromFS) moduleInfo.licenses = licenseFromFS;
 
                     if (moduleInfo.licenses.length === 0) moduleInfo.licenses = 'UNKNOWN';
+                    
+                    //if licenses array only contains one license remove the array
+                    if (_.isArray(moduleInfo.licenses) && moduleInfo.licenses.length === 1) 
+                        moduleInfo.licenses = moduleInfo.licenses[0];
 
                     if (Object.keys(output).length === packages.length){
                         callback(output);

--- a/lib/index.js
+++ b/lib/index.js
@@ -46,9 +46,25 @@ exports.init = function(options, callback){
                     var licenseFromFS = packageLicense(path.resolve(options.directory, package));
                     if (licenseFromFS) moduleInfo.licenses = moduleInfo.licenses.concat(licenseFromFS);
 
-                    if (moduleInfo.licenses.length === 0) moduleInfo.licenses = 'UNKNOWN';
+                    if (moduleInfo.licenses.length === 0){
+                        moduleInfo.licenses = 'UNKNOWN';
+                    } else {
+                        // remove licenses with asterisk if the same license already exists
+                        moduleInfo.licenses = _.filter(moduleInfo.licenses, function(license){
+                            var iAsk =  license.indexOf('*');
+                            return (
+                                // return well defined licenses (without an asterisk)
+                                iAsk == -1 ||  
+                                // remove licenses with asterisk if the same license already exists
+                                _.indexOf(moduleInfo.licenses, license.substring(0, iAsk)) < 0
+                            ); 
+                        });
+                        
+                        // remove duplicated licenses
+                        moduleInfo.licenses = _.uniq(moduleInfo.licenses);
+                    }
                     
-                    //if licenses array only contains one license remove the array
+                    // if licenses array only contains one license remove the array
                     if (_.isArray(moduleInfo.licenses) && moduleInfo.licenses.length === 1) 
                         moduleInfo.licenses = moduleInfo.licenses[0];
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bower-license",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Generates a list of bower dependencies for a project",
   "preferGlobal": "true",
   "main": "./lib/index",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bower-license",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Generates a list of bower dependencies for a project",
   "preferGlobal": "true",
   "main": "./lib/index",
@@ -18,6 +18,10 @@
     "oss"
   ],
   "author": "Duncan Wong <baduncaduncan@gmail.com>",
+  "contributors": [{
+    "name": "Alexander Wunschik",
+    "email": "dev@wunschik.net"
+  }],
   "license": "Apache2",
   "bugs": {
     "url": "https://github.com/AceMetrix/bower-license/issues"
@@ -25,7 +29,7 @@
   "dependencies": {
     "bower-json": "~0.4.0",
     "npm-license": "~0.1.9",
-    "package-license": "~0.1.1",
+    "package-license": "~0.2.0",
     "raptor-args": "~1.0.1",
     "treeify": "~1.0.1",
     "underscore": "~1.5.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bower-license",
-  "version": "0.2.5",
+  "version": "0.2.3",
   "description": "Generates a list of bower dependencies for a project",
   "preferGlobal": "true",
   "main": "./lib/index",


### PR DESCRIPTION
**BUGFIX: enhance with package-license instead of overwriting**

Well defined licenses (e.g. from bower.json) got overwritten by package-licenses. This is actually a bug. Because I fixed this I had to remove licenses with asterisk if the same license already exists.

**If licenses array only contains one license remove the array**

e.g. jquery-ui would return:
```
    "jquery-ui@1.11.1": {
        "licenses": [
            "MIT"
        ],
        "repository": "https://github.com/jquery/jquery-ui"
    },
```
i changed this to:
```
    "jquery-ui@1.11.1": {
        "licenses": "MIT",
        "repository": "https://github.com/jquery/jquery-ui"
    },
```