### PR TITLE
Make it possible for multible licenses to be detected

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -45,9 +45,25 @@ exports.init = function(options, callback){
 
                     // enhance with package-license
                     var licenseFromFS = packageLicense(path.resolve(options.directory, package));
-                    if (licenseFromFS) moduleInfo.licenses = licenseFromFS;
+                    if (licenseFromFS) moduleInfo.licenses = moduleInfo.licenses.concat(licenseFromFS);
 
-                    if (moduleInfo.licenses.length === 0) moduleInfo.licenses = 'UNKNOWN';
+                    if (moduleInfo.licenses.length === 0){
+                        moduleInfo.licenses = 'UNKNOWN';
+                    } else {
+                        // remove licenses with asterisk if the same license already exists
+                        moduleInfo.licenses = _.filter(moduleInfo.licenses, function(license){
+                            var iAsk =  license.indexOf('*');
+                            return (
+                                // return well defined licenses (without an asterisk)
+                                iAsk == -1 ||  
+                                // remove licenses with asterisk if the same license already exists
+                                _.indexOf(moduleInfo.licenses, license.substring(0, iAsk)) < 0
+                            ); 
+                        });
+                        
+                        // remove duplicated licenses
+                        moduleInfo.licenses = _.uniq(moduleInfo.licenses);
+                    }
 
                     if (Object.keys(output).length === packages.length){
                         callback(output);


### PR DESCRIPTION
At the moment well defined licenses (e.g. from _bower.json_ or _package.json_) get overwritten by licenses detected by _package-licenses_. This is actually a bug because for example a single mention of the simple string "MIT" overwrites these well defined licenses.

Also it is possible that packages have multiple licenses (~~e.g. [almon](https://github.com/jrburke/almond/blob/master/package.json)~~). This is also fixed here.
