### PR TITLE
Deal with collisions between similarly-named or aliased packages

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,7 @@ exports.init = function(options, callback){
     options = _.extend({}, {directory: 'bower_components'}, options);
     // check each bower package recursively
     if (!fs.existsSync(options.directory)){
-        throw 'No bower components found in ' + options.directory + '.  Run bower install first or check your .bowerrc file';        
+        throw 'No bower components found in ' + options.directory + '.  Run bower install first or check your .bowerrc file';
     }
     var packages = fs.readdirSync(options.directory);
     packages.forEach(function(package){
@@ -29,19 +29,22 @@ exports.init = function(options, callback){
             bowerJson.read(filename, function(err, bowerData){
                 var moduleInfo = {licenses: []};
                 if (bowerData.license) moduleInfo.licenses = moduleInfo.licenses.concat(bowerData.license);
-                if (bowerData.repository) moduleInfo.repository = bowerData.repository
+                if (bowerData.repository) moduleInfo.repository = bowerData.repository;
                 if (bowerData.homepage) moduleInfo.homepage = bowerData.homepage;
 
                 // enhance with npm-license
                 npmLicense.init({start: path.resolve(options.directory, package)}, function(npmData){
-                    output[bowerData.name + '@' + bowerData.version] = moduleInfo;
+                    var name = bowerData.name;
+                    if(package !== name){
+                        name = name + '(' + package + ')';
+                    }
+                    output[name + '@' + bowerData.version] = moduleInfo;
 
                     for (var packageName in npmData){
                         if (npmData[packageName].licenses && npmData[packageName].licenses !== 'UNKNOWN')
-                            moduleInfo.licenses = moduleInfo.licenses.concat(npmData[packageName].licenses)
+                            moduleInfo.licenses = moduleInfo.licenses.concat(npmData[packageName].licenses);
                         if (npmData[packageName].repository)
                             moduleInfo.repository = npmData[packageName].repository;
-
                     }
 
                     // enhance with package-license
@@ -53,15 +56,15 @@ exports.init = function(options, callback){
                     } else {
                         // remove licenses with asterisk if the same license already exists
                         moduleInfo.licenses = _.filter(moduleInfo.licenses, function(license){
-                            var iAsk =  license.indexOf('*');
+                            var iAsk = license.indexOf('*');
                             return (
                                 // return well defined licenses (without an asterisk)
-                                iAsk == -1 ||  
+                                iAsk === -1 ||
                                 // remove licenses with asterisk if the same license already exists
                                 _.indexOf(moduleInfo.licenses, license.substring(0, iAsk)) < 0
-                            ); 
+                            );
                         });
-                        
+
                         // remove duplicated licenses
                         moduleInfo.licenses = _.uniq(moduleInfo.licenses);
                     }


### PR DESCRIPTION
If I have the following `bower.json` file in my project, bower-license quits without printing any output:

```json
{
  "dependencies": {
    "moment": "2.9.0",
    "momentjs": "2.9.0"
}
```

Admittedly, this would be stupid, but you could effectively end up in the same situation if moment is declared as a transitive dependency of one of your other packages.  For example, if my package depends on Libraries A and B, where Library A depends on `moment` and Library B depends on `momentjs`), I effectively end up with both `moment` and `momentjs`.  While neither library is particularly incorrect, Bower isn't smart enough to realize that it's installing the same package twice.

Because `bower-license` uses the directory names within `bower_components` for input, but organizes outputs by package name, we end up with collisions if the same package is installed in two directories.  Among other things, one of the two instances of the package will clobber the other, and effectively prevent the output callback from ever firing (because it depends on the number of packages in the output matching the number of directories in the input).

This PR detects cases where the package's directory name does not directly correspond to its package name.  If such a discrepency exists, the package name is output as `"packageName(directoryName)`, preventing these collisions.