### PR TITLE
Add error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Show a project's bower dependencies and their licenses
 #Installation
 
 ```
-npm install -g bower-license 
+npm install -g bower-license
 
 ```
 #Usage
@@ -81,12 +81,14 @@ Used as a library:
 
 ```
 var license = require('bower-license');
-license.init('/path/to/package', function(licenseMap){
-    console.log(licenseMap);
+license.init('/path/to/package', function(licenseMap, err){
+    if (!err) {
+        console.log(licenseMap);
+    }
 });
 ```
 
 
-   
+
 #Notes
 Any asterisks (*) after a license value were implictly discovered/detected by their README or LICENSE file and may not be truly reliable.

--- a/bin/bower-license
+++ b/bin/bower-license
@@ -13,7 +13,7 @@ var parsed = require('raptor-args')
             description: 'Export format, could be json or tree (default)',
             defaultValue: 'tree'
         }
-        
+
     })
     .usage('Usage: $0 [options]')
     .example(
@@ -23,7 +23,7 @@ var parsed = require('raptor-args')
         if (result.help) {
             this.printUsage();
             process.exit(0);
-        }        
+        }
     })
     .onError(function(err) {
         this.printUsage();
@@ -32,10 +32,14 @@ var parsed = require('raptor-args')
     })
     .parse();
 
-checker.init({}, function(json){
-  if (parsed.export==='json'){
-      checker.printJson(json);
-  } else{
-      checker.printTree(json);
-  }
+checker.init({}, function(json, err){
+    if (!!err) {
+        console.log(err);
+    } else {
+        if (parsed.export==='json'){
+            checker.printJson(json);
+        } else{
+            checker.printTree(json);
+        }
+    }
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,8 +16,9 @@ exports.init = function(options, callback){
     }
     options = _.extend({}, {directory: 'bower_components'}, options);
     // check each bower package recursively
-    if (!fs.existsSync(options.directory)){
-        throw 'No bower components found in ' + options.directory + '.  Run bower install first or check your .bowerrc file';        
+    if (!fs.existsSync(options.directory)) {
+      callback(null, new Error('No bower components found in ' + options.directory + '. Run bower install first or check your .bowerrc file'));
+      return;
     }
     var packages = fs.readdirSync(options.directory);
     packages.forEach(function(package){
@@ -27,6 +28,12 @@ exports.init = function(options, callback){
                 return;
             }
             bowerJson.read(filename, function(err, bowerData){
+
+                if (!!err) {
+                    callback(null, err);
+                    return;
+                }
+
                 var moduleInfo = {licenses: []};
                 if (bowerData.license) moduleInfo.licenses = moduleInfo.licenses.concat(bowerData.license);
                 if (bowerData.repository) moduleInfo.repository = bowerData.repository
@@ -56,12 +63,12 @@ exports.init = function(options, callback){
                             var iAsk =  license.indexOf('*');
                             return (
                                 // return well defined licenses (without an asterisk)
-                                iAsk == -1 ||  
+                                iAsk == -1 ||
                                 // remove licenses with asterisk if the same license already exists
                                 _.indexOf(moduleInfo.licenses, license.substring(0, iAsk)) < 0
-                            ); 
+                            );
                         });
-                        
+
                         // remove duplicated licenses
                         moduleInfo.licenses = _.uniq(moduleInfo.licenses);
                     }


### PR DESCRIPTION
Error handling will be a pleasure for external libraries.
A basic throw will stop the entire process and there won't be a return or callback.

Now you receive an error if you have no bower_components or something went wrong with bower-json.