### PR TITLE
Deal with collisions between aliased packages

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,7 @@ var packageLicense = require('package-license');
 var path = require('path');
 
 var output = {};
+var completed = [];
 exports.init = function(options, callback){
     // read .bowerrc
     if (fs.existsSync('.bowerrc')){
@@ -73,7 +74,8 @@ exports.init = function(options, callback){
                         moduleInfo.licenses = _.uniq(moduleInfo.licenses);
                     }
 
-                    if (Object.keys(output).length === packages.length){
+                    completed.push(package);
+                    if (completed.length === packages.length){
                         callback(output);
                     }
                 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,6 +26,7 @@ exports.init = function(options, callback){
         bowerJson.find(path.resolve(options.directory, package), function(err, filename){
             if (!filename){
                 output[package] = {licenses: 'UNKNOWN'};
+                completed.push(package);
                 return;
             }
             bowerJson.read(filename, function(err, bowerData){


### PR DESCRIPTION
This is an alternative solution for the issue mentioned in #9. Rather than creating 2 entries in the output for the duplicated package(s), it simply changes how packages are tracked for completion.