### PR TITLE
Look at .bower.json before falling back to bower.json.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22,7 +22,7 @@ exports.init = function(options, callback){
     }
     var packages = fs.readdirSync(options.directory);
     packages.forEach(function(package){
-        bowerJson.find(path.resolve(options.directory, package), function(err, filename){
+        bowerJson.find(path.resolve(options.directory, package), ['.bower.json', 'bower.json', 'component.json'], function(err, filename){
             if (!filename){
                 output[package] = {licenses: 'UNKNOWN'};
                 return;


### PR DESCRIPTION
It seems like `.bower.json` should be the first choice for retrieving the package info.

Bower always creates a `.bower.json` file that contains the same info as `bower.json`, but with extra properties. The bower maintainers also say that tools should use `.bower.json`:

> The ultimate answer is: use .bower.json.

see https://github.com/bower/bower/issues/1174
