### PR TITLE
Fall back to npm "version" value if bower.json is missing that property.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -41,7 +41,11 @@ exports.init = function(options, callback){
 
                 // enhance with npm-license
                 npmLicense.init({start: path.resolve(options.directory, package)}, function(npmData){
-                    output[bowerData.name + '@' + bowerData.version] = moduleInfo;
+                    var npmVersion;
+                    if (Object.keys(npmData).length > 0)
+                        npmVersion = Object.keys(npmData)[0].split('@')[1];
+                    var version = bowerData.version || npmVersion;
+                    output[bowerData.name + '@' + version] = moduleInfo;
 
                     for (var packageName in npmData){
                         if (npmData[packageName].licenses && npmData[packageName].licenses !== 'UNKNOWN')


### PR DESCRIPTION
The `version` property in the bower specs is [officially deprecated](https://github.com/bower/spec/blob/master/json.md#version). This change will use the `version` in the `package.json` if it doesn't exist in the bower manifest.