### PR TITLE
Tolerate object-valued bower license property

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -36,7 +36,7 @@ exports.init = function(options, callback){
                 }
 
                 var moduleInfo = {licenses: []};
-                if (bowerData.license) moduleInfo.licenses = moduleInfo.licenses.concat(bowerData.license);
+                if (bowerData.license) moduleInfo.licenses = moduleInfo.licenses.concat(bowerData.license.type || bowerData.license);
                 if (bowerData.repository) moduleInfo.repository = bowerData.repository;
                 if (bowerData.homepage) moduleInfo.homepage = bowerData.homepage;
 


### PR DESCRIPTION
I found at least one Bower package (`serialized-lru-cache`) that defines its license as:

```
  "license": {
    "type": "MIT",
    "url": "http://github.com/jmendiara/serialized-lru-cache/raw/master/LICENSE"
  },
```

No idea if it's spec-compliant or not, but it will crash `bower-license` and it's a simple fix, so...

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/acemetrix/bower-license/17)

<!-- Reviewable:end -->
