### PR TITLE
Set npm-license dependency version to ~0.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "bower-json": "~0.4.0",
-    "npm-license": "~0.1.9",
+    "npm-license": "~0.3.3",
     "package-license": "~0.1.1",
     "raptor-args": "~1.0.1",
     "treeify": "~1.0.1",


### PR DESCRIPTION
This is required so the fix https://github.com/AceMetrix/npm-license/pull/19 in npm-license takes effect and solves #18