### PR TITLE
Update bower-json version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bower-license",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Generates a list of bower dependencies for a project",
   "preferGlobal": "true",
   "main": "./lib/index",
@@ -23,7 +23,7 @@
     "url": "https://github.com/AceMetrix/bower-license/issues"
   },
   "dependencies": {
-    "bower-json": "~0.4.0",
+    "bower-json": "~0.8.0",
     "npm-license": "~0.3.3",
     "package-license": "~0.1.1",
     "raptor-args": "~1.0.1",


### PR DESCRIPTION
Avoid deprecated package warning:
deprecated graceful-fs@2.0.3: graceful-fs v3.0.0 and before will fail on node releases >= v7.0. Please update to graceful-fs@^4.0.0 as soon as possible